### PR TITLE
small fix to make things work on linux/osx

### DIFF
--- a/lib/template-generator-fields-list.coffee
+++ b/lib/template-generator-fields-list.coffee
@@ -2,6 +2,7 @@
 TemplateGeneratorUtilities = require './template-generator-utilities'
 _ = require 'underscore'
 CSON = require 'season'
+path = require 'path'
 
 buildTextEditor = require './build-text-editor'
 
@@ -55,7 +56,7 @@ class FieldsListView extends View
       fieldValue = fElement.children[0].getModel().getText()
       sFieldsArray.push [fieldName, fieldValue]
 
-    targetPath = "#{atom.project.getPaths()[0]}\\#{@selectedPathTextField.getModel().getText()}"
+    targetPath = path.join("#{atom.project.getPaths()[0]}","#{@selectedPathTextField.getModel().getText()}")
     transformedTemplate = TemplateGeneratorUtilities.tansformTemplateObjectWithFields @template, sFieldsArray
     TemplateGeneratorUtilities.generateFilesUsingTemplateObject transformedTemplate, targetPath
 


### PR DESCRIPTION
I've noticed that under my Ubuntu when I want to generate template (let's say a Folder) it's being created in a parent directory with a parentDir\Folder format so I end up with something like this: /home/max/Code/parentDir\Folder

Fix: replaced hardcoded environmental separator (\\) on line 58 in template-generator-fields-list with path module join function